### PR TITLE
RST-5409 Retain latched messages from each unique publisher

### DIFF
--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -127,6 +127,9 @@ struct ROSBAG_DECL SnapshotMessage
   boost::shared_ptr<ros::M_string> connection_header;
   // ROS time when messaged arrived (does not use header stamp)
   ros::Time time;
+
+  // Get the callid field from the message connection header. Returns empty string if callerid is not found
+  std::string getCallerId() const;
 };
 
 /* Stores a queue of buffered messages for a single topic ensuring
@@ -183,9 +186,11 @@ private:
   void _clear();
   // Truncate front of queue as needed to fit a new message of specified size and time. Returns False if this is
   // impossible.
-  bool preparePush(int32_t size, ros::Time const& time);
+  bool preparePush(int32_t size, ros::Time const& time, std::string const& callerid);
   // Returns true if queue messages are latched, false if not latched or queue is empty. Does not obtain lock
   bool _is_latched();
+  // Removes all messages from the specified callerid
+  void _remove_callerid(std::string callerid);
 };
 
 /* Snapshotter node. Maintains a circular buffer of the most recent messages from configured topics

--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -159,7 +159,7 @@ public:
   // Removes the message at the front of the queue (oldest) and returns it
   SnapshotMessage pop();
   // Removes the message at the back of the queue (newest) and returns it
-  SnapshotMessage pop_back();
+  SnapshotMessage popBack();
   // Returns the time difference between back and front of queue, or 0 if size <= 1
   ros::Duration duration() const;
   // Clear internal buffer
@@ -180,17 +180,17 @@ private:
   void _push(SnapshotMessage const& msg);
   // Internal pop which does not obtain lock
   SnapshotMessage _pop();
-  // Internal pop_back which does not obtain lock
-  SnapshotMessage _pop_back();
+  // Internal popBack which does not obtain lock
+  SnapshotMessage _popBack();
   // Internal clear which does not obtain lock
   void _clear();
   // Truncate front of queue as needed to fit a new message of specified size and time. Returns False if this is
   // impossible.
-  bool preparePush(int32_t size, ros::Time const& time, std::string const& callerid);
+  bool preparePush(int32_t size, ros::Time const& time, const std::string& callerid);
   // Returns true if queue messages are latched, false if not latched or queue is empty. Does not obtain lock
-  bool _is_latched();
+  bool isLatched();
   // Removes all messages from the specified callerid
-  void _remove_callerid(std::string callerid);
+  void removeCallerid(const std::string& callerid);
 };
 
 /* Snapshotter node. Maintains a circular buffer of the most recent messages from configured topics

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -34,6 +34,7 @@
 #include <queue>
 #include <string>
 #include <time.h>
+#include <unordered_set>
 #include <vector>
 #include <boost/filesystem.hpp>
 #include <boost/scope_exit.hpp>
@@ -99,6 +100,19 @@ MessageQueue::MessageQueue(SnapshotterTopicOptions const& options) : options_(op
 {
 }
 
+std::string SnapshotMessage::getCallerId() const
+{
+  std::string callerid = "";
+  ros::M_string::const_iterator it = connection_header->find("callerid");
+
+  if (it != connection_header->end())
+  {
+    callerid = it->second;
+  }
+
+  return callerid;
+}
+
 void MessageQueue::setSubscriber(shared_ptr<ros::Subscriber> sub)
 {
   sub_ = sub;
@@ -123,13 +137,33 @@ void MessageQueue::clear()
 
 void MessageQueue::_clear()
 {
-  if (_is_latched()) {
-    // Restore the latest message for latched topics
-    SnapshotMessage latest = _pop_back();
+  if (_is_latched())
+  {
+    // Restore the newest message from each unique publisher of latched topics
+    std::unordered_set<std::string> callers = {};
+    queue_t saved;
+
+    for (auto m = queue_.rbegin(); m != queue_.rend(); m++)
+    {
+      std::string callerid = m->getCallerId();
+      if (callers.find(callerid) == callers.end())
+      {
+          saved.push_back(*m);
+          callers.insert(callerid);
+      }
+    }
+
     queue_.clear();
     size_ = 0;
-    _push(latest);
-  } else {
+
+    // Push saved messages into queue from oldest to newest
+    for (auto m = saved.rbegin(); m != saved.rend(); m++)
+    {
+      _push(*m);
+    }
+  }
+  else
+  {
     queue_.clear();
     size_ = 0;
   }
@@ -143,7 +177,7 @@ ros::Duration MessageQueue::duration() const
   return queue_.back().time - queue_.front().time;
 }
 
-bool MessageQueue::preparePush(int32_t size, ros::Time const& time)
+bool MessageQueue::preparePush(int32_t size, ros::Time const& time, std::string const& callerid)
 {
   // If new message is older than back of queue, time has gone backwards and buffer must be cleared
   if (!queue_.empty() && time < queue_.back().time)
@@ -161,9 +195,14 @@ bool MessageQueue::preparePush(int32_t size, ros::Time const& time)
     while (queue_.size() != 0 && size_ + size > options_.memory_limit_)
       _pop();
 
-  // If duration limit is encforced, remove elements from front of queue until duration limit would be met once message
+  // If topic is latched, ignore duration limit but remove all previous messages from the specified callerid
+  if (_is_latched())
+  {
+    _remove_callerid(callerid);
+  }
+  // If duration limit is enforced, remove elements from front of queue until duration limit would be met once message
   // is added
-  if (options_.duration_limit_ > SnapshotterTopicOptions::NO_DURATION_LIMIT && queue_.size() != 0)
+  else if (options_.duration_limit_ > SnapshotterTopicOptions::NO_DURATION_LIMIT && queue_.size() != 0)
   {
     ros::Duration dt = time - queue_.front().time;
     while (dt > options_.duration_limit_)
@@ -219,7 +258,7 @@ void MessageQueue::_push(SnapshotMessage const& _out)
 {
   int32_t size = _out.msg->size();
   // If message cannot be added without violating limits, it must be dropped
-  if (!preparePush(size, _out.time))
+  if (!preparePush(size, _out.time, _out.getCallerId()))
     return;
   queue_.push_back(_out);
   // Add size of new message to running count to maintain correctness
@@ -264,19 +303,37 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const& start, Time const
   return range_t(begin, end);
 }
 
-bool MessageQueue::_is_latched() {
+bool MessageQueue::_is_latched()
+{
   bool latched = false;
 
-  if (!queue_.empty()) {
+  if (!queue_.empty())
+  {
     SnapshotMessage latest = queue_.back();
 
     ros::M_string::const_iterator it = latest.connection_header->find("latching");
-    if ((it != latest.connection_header->end()) && (it->second == "1")) { 
+    if ((it != latest.connection_header->end()) && (it->second == "1"))
+    {
       latched = true;
     }
   }
 
   return latched;
+}
+
+void MessageQueue::_remove_callerid(std::string callerid)
+{
+  for (auto it = queue_.begin(); it != queue_.end(); )
+  {
+    if (it->getCallerId() == callerid)
+    {
+      it = queue_.erase(it);
+    }
+    else
+    {
+      ++it;
+    }
+  }
 }
 
 const int Snapshotter::QUEUE_SIZE = 10;
@@ -394,8 +451,9 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
   try
   {
     ros::Time start = req.start_time;
-    
-    if (start == ros::Time(0)) {
+
+    if (start == ros::Time(0))
+    {
       start = now - message_queue.options_.duration_limit_;
     }
 
@@ -403,7 +461,8 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
     {
       SnapshotMessage msg = *msg_it;
       // Latched messages can have old timestamps so set the timestamp to the bag start time in this case
-      if (msg.time < start) {
+      if (msg.time < start)
+      {
         msg.time = start;
       }
       bag.write(topic, msg.time, msg.msg, msg.connection_header);

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -137,7 +137,7 @@ void MessageQueue::clear()
 
 void MessageQueue::_clear()
 {
-  if (_is_latched())
+  if (isLatched())
   {
     // Restore the newest message from each unique publisher of latched topics
     std::unordered_set<std::string> callers = {};
@@ -148,8 +148,8 @@ void MessageQueue::_clear()
       std::string callerid = m->getCallerId();
       if (callers.find(callerid) == callers.end())
       {
-          saved.push_back(*m);
-          callers.insert(callerid);
+        saved.push_back(*m);
+        callers.insert(callerid);
       }
     }
 
@@ -177,7 +177,7 @@ ros::Duration MessageQueue::duration() const
   return queue_.back().time - queue_.front().time;
 }
 
-bool MessageQueue::preparePush(int32_t size, ros::Time const& time, std::string const& callerid)
+bool MessageQueue::preparePush(int32_t size, ros::Time const& time, const std::string& callerid)
 {
   // If new message is older than back of queue, time has gone backwards and buffer must be cleared
   if (!queue_.empty() && time < queue_.back().time)
@@ -196,9 +196,9 @@ bool MessageQueue::preparePush(int32_t size, ros::Time const& time, std::string 
       _pop();
 
   // If topic is latched, ignore duration limit but remove all previous messages from the specified callerid
-  if (_is_latched())
+  if (isLatched())
   {
-    _remove_callerid(callerid);
+    removeCallerid(callerid);
   }
   // If duration limit is enforced, remove elements from front of queue until duration limit would be met once message
   // is added
@@ -238,10 +238,10 @@ SnapshotMessage MessageQueue::pop()
   return _pop();
 }
 
-SnapshotMessage MessageQueue::pop_back()
+SnapshotMessage MessageQueue::popBack()
 {
   boost::mutex::scoped_lock l(lock);
-  return _pop_back();
+  return _popBack();
 }
 
 int64_t MessageQueue::getMessageSize(SnapshotMessage const& snapshot_msg) const
@@ -274,7 +274,7 @@ SnapshotMessage MessageQueue::_pop()
   return tmp;
 }
 
-SnapshotMessage MessageQueue::_pop_back()
+SnapshotMessage MessageQueue::_popBack()
 {
   SnapshotMessage tmp = queue_.back();
   queue_.pop_back();
@@ -290,7 +290,7 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const& start, Time const
 
   // Increment / Decrement iterators until time contraints are met
   // Don't increment the begin iterator for latched messages since their timestamps can be old
-  if (!start.isZero() && !_is_latched())
+  if (!start.isZero() && !isLatched())
   {
     while (begin != end && (*begin).time < start)
       ++begin;
@@ -303,7 +303,7 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const& start, Time const
   return range_t(begin, end);
 }
 
-bool MessageQueue::_is_latched()
+bool MessageQueue::isLatched()
 {
   bool latched = false;
 
@@ -321,7 +321,7 @@ bool MessageQueue::_is_latched()
   return latched;
 }
 
-void MessageQueue::_remove_callerid(std::string callerid)
+void MessageQueue::removeCallerid(const std::string& callerid)
 {
   for (auto it = queue_.begin(); it != queue_.end(); )
   {


### PR DESCRIPTION
I'm not sure, but I think this has recently become an issue due to the `map -> /<$ROBOT>/dock` transform being published on the `/tf_static` topic. Whenever a robot docks, that transform is published and becomes the latest message on that latched topic. When a snapshot is triggered, only the latest message was being saved so subsequent snapshots would only contain that transform. If that transform is not new, then I'm not sure why this issue hasn't come up before.

To fix the issue for all latched topics:

- When adding a new message to the queue, remove previous messages from the same publisher while ignoring timestamps
- When a snapshot is triggered, restore the latest message from each publisher

I tested in local-sim by sending the bot to dock so the dock transform is published, then triggered 2 snapshots to make sure all static transforms were bagged including the dock one. I then sent the bot to charge again so a new dock transform was published, after which I triggered 2 more snapshots and checked that only the newest dock transform was being bagged along with the others.

I also fixed some linting errors that I introduced with my last PR and apparently didn't test for so there's a bit of extra noise in this PR.

