### PR TITLE
RST-7378 Buffer Additional Latched Messages

### DIFF
--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -131,7 +131,7 @@ struct ROSBAG_DECL SnapshotMessage
   // Get the callid field from the message connection header. Returns empty string if callerid is not found
   std::string getCallerId() const;
   // Return true if this message is from a latched topic
-  bool is_latched() const;
+  bool isLatched() const;
 };
 
 /* Stores a queue of buffered messages for a single topic ensuring
@@ -192,7 +192,7 @@ private:
   // impossible.
   bool preparePush(int32_t size, ros::Time const& time, const std::string& callerid);
   // Returns true if queue contains latched messages, false if not or queue is empty. Does not obtain lock
-  bool is_latched();
+  bool isLatched();
   // Removes all messages from the specified callerid
   void removeCallerid(const std::string& callerid);
 };

--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -130,6 +130,8 @@ struct ROSBAG_DECL SnapshotMessage
 
   // Get the callid field from the message connection header. Returns empty string if callerid is not found
   std::string getCallerId() const;
+  // Return true if this message is from a latched topic
+  bool is_latched() const;
 };
 
 /* Stores a queue of buffered messages for a single topic ensuring
@@ -174,6 +176,8 @@ public:
 
   // Return the total message size including the meta-information
   int64_t getMessageSize(SnapshotMessage const& msg) const;
+  // Latest messages from each publisher on a latched topic
+  std::map<std::string, SnapshotMessage> latest_latched;
 
 private:
   // Internal push whitch does not obtain lock
@@ -187,8 +191,8 @@ private:
   // Truncate front of queue as needed to fit a new message of specified size and time. Returns False if this is
   // impossible.
   bool preparePush(int32_t size, ros::Time const& time, const std::string& callerid);
-  // Returns true if queue messages are latched, false if not latched or queue is empty. Does not obtain lock
-  bool isLatched();
+  // Returns true if queue contains latched messages, false if not or queue is empty. Does not obtain lock
+  bool is_latched();
   // Removes all messages from the specified callerid
   void removeCallerid(const std::string& callerid);
 };

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -195,14 +195,9 @@ bool MessageQueue::preparePush(int32_t size, ros::Time const& time, const std::s
     while (queue_.size() != 0 && size_ + size > options_.memory_limit_)
       _pop();
 
-  // If topic is latched, ignore duration limit but remove all previous messages from the specified callerid
-  if (isLatched())
-  {
-    removeCallerid(callerid);
-  }
   // If duration limit is enforced, remove elements from front of queue until duration limit would be met once message
   // is added
-  else if (options_.duration_limit_ > SnapshotterTopicOptions::NO_DURATION_LIMIT && queue_.size() != 0)
+  if (options_.duration_limit_ > SnapshotterTopicOptions::NO_DURATION_LIMIT && queue_.size() != 0)
   {
     ros::Duration dt = time - queue_.front().time;
     while (dt > options_.duration_limit_)
@@ -319,21 +314,6 @@ bool MessageQueue::isLatched()
   }
 
   return latched;
-}
-
-void MessageQueue::removeCallerid(const std::string& callerid)
-{
-  for (auto it = queue_.begin(); it != queue_.end(); )
-  {
-    if (it->getCallerId() == callerid)
-    {
-      it = queue_.erase(it);
-    }
-    else
-    {
-      ++it;
-    }
-  }
 }
 
 const int Snapshotter::QUEUE_SIZE = 10;

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -302,21 +302,6 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const& start, Time const
 
 bool MessageQueue::is_latched()
 {
-  // bool latched = false;
-
-  // if (!queue_.empty())
-  // {
-  //   SnapshotMessage latest = queue_.back();
-
-  //   ros::M_string::const_iterator it = latest.connection_header->find("latching");
-  //   if ((it != latest.connection_header->end()) && (it->second == "1"))
-  //   {
-  //     latched = true;
-  //   }
-  // }
-
-  // return latched;
-
   return !latest_latched.empty();
 }
 
@@ -476,7 +461,7 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
     {
       for (auto it = message_queue.latest_latched.begin(); it != message_queue.latest_latched.end(); ++it)
       {
-        // If there are any publishers that are not included in this bag, add the latest message from the publisher
+        // If any known latched publishers are not included in this bag, add the latest message from them
         if (std::find(callers.begin(), callers.end(), it->first) == callers.end())
         {
           // Latched messages can have old timestamps so set the timestamp to the bag start time in this case

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -113,6 +113,11 @@ std::string SnapshotMessage::getCallerId() const
   return callerid;
 }
 
+bool SnapshotMessage::is_latched() const
+{
+  return connection_header->find("latching") != connection_header->end();
+}
+
 void MessageQueue::setSubscriber(shared_ptr<ros::Subscriber> sub)
 {
   sub_ = sub;
@@ -137,35 +142,14 @@ void MessageQueue::clear()
 
 void MessageQueue::_clear()
 {
-  if (isLatched())
+  queue_.clear();
+  size_ = 0;
+
+  // Restore the latest message from each unique publisher of latched topics
+  for (auto msg : latest_latched)
   {
-    // Restore the newest message from each unique publisher of latched topics
-    std::unordered_set<std::string> callers = {};
-    queue_t saved;
-
-    for (auto m = queue_.rbegin(); m != queue_.rend(); m++)
-    {
-      std::string callerid = m->getCallerId();
-      if (callers.find(callerid) == callers.end())
-      {
-        saved.push_back(*m);
-        callers.insert(callerid);
-      }
-    }
-
-    queue_.clear();
-    size_ = 0;
-
-    // Push saved messages into queue from oldest to newest
-    for (auto m = saved.rbegin(); m != saved.rend(); m++)
-    {
-      _push(*m);
-    }
-  }
-  else
-  {
-    queue_.clear();
-    size_ = 0;
+    // Any message here has already passed checks so push straight to the queue
+    queue_.push_back(msg.second);
   }
 }
 
@@ -216,6 +200,7 @@ bool MessageQueue::preparePush(int32_t size, ros::Time const& time, const std::s
 
   return true;
 }
+
 void MessageQueue::push(SnapshotMessage const& _out)
 {
   boost::mutex::scoped_try_lock l(lock);
@@ -255,6 +240,23 @@ void MessageQueue::_push(SnapshotMessage const& _out)
   // If message cannot be added without violating limits, it must be dropped
   if (!preparePush(size, _out.time, _out.getCallerId()))
     return;
+
+  std::string callerId = _out.getCallerId();
+  // Save the latest from each publisher on a latched topic
+  if (_out.is_latched())
+  {
+    auto it = latest_latched.find(callerId);
+
+    if (it != latest_latched.end())
+    {
+      it->second = _out;
+    }
+    else
+    {
+      latest_latched.insert(std::make_pair(callerId, _out));
+    }
+  }
+
   queue_.push_back(_out);
   // Add size of new message to running count to maintain correctness
   size_ += getMessageSize(_out);
@@ -285,7 +287,7 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const& start, Time const
 
   // Increment / Decrement iterators until time contraints are met
   // Don't increment the begin iterator for latched messages since their timestamps can be old
-  if (!start.isZero() && !isLatched())
+  if (!start.isZero() && !is_latched())
   {
     while (begin != end && (*begin).time < start)
       ++begin;
@@ -298,22 +300,24 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const& start, Time const
   return range_t(begin, end);
 }
 
-bool MessageQueue::isLatched()
+bool MessageQueue::is_latched()
 {
-  bool latched = false;
+  // bool latched = false;
 
-  if (!queue_.empty())
-  {
-    SnapshotMessage latest = queue_.back();
+  // if (!queue_.empty())
+  // {
+  //   SnapshotMessage latest = queue_.back();
 
-    ros::M_string::const_iterator it = latest.connection_header->find("latching");
-    if ((it != latest.connection_header->end()) && (it->second == "1"))
-    {
-      latched = true;
-    }
-  }
+  //   ros::M_string::const_iterator it = latest.connection_header->find("latching");
+  //   if ((it != latest.connection_header->end()) && (it->second == "1"))
+  //   {
+  //     latched = true;
+  //   }
+  // }
 
-  return latched;
+  // return latched;
+
+  return !latest_latched.empty();
 }
 
 const int Snapshotter::QUEUE_SIZE = 10;
@@ -431,12 +435,21 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
   try
   {
     ros::Time start = req.start_time;
+    bool latched = message_queue.is_latched();
 
     if (start == ros::Time(0))
     {
-      start = now - message_queue.options_.duration_limit_;
+      if (latched)
+      {
+        start = message_queue.queue_.front().time;
+      }
+      else
+      {
+        start = now - message_queue.options_.duration_limit_;
+      }
     }
 
+    std::vector<std::string> callers;
     for (MessageQueue::range_t::first_type msg_it = range.first; msg_it != range.second; ++msg_it)
     {
       SnapshotMessage msg = *msg_it;
@@ -446,6 +459,31 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
         msg.time = start;
       }
       bag.write(topic, msg.time, msg.msg, msg.connection_header);
+
+      // Keep a list of publishers included in this bag for latched topics
+      if (latched)
+      {
+        std::string caller = msg.getCallerId();
+
+        if (std::find(callers.begin(), callers.end(), caller) == callers.end())
+        {
+          callers.push_back(caller);
+        }
+      }
+    }
+
+    if (latched)
+    {
+      for (auto it = message_queue.latest_latched.begin(); it != message_queue.latest_latched.end(); ++it)
+      {
+        // If there are any publishers that are not included in this bag, add the latest message from the publisher
+        if (std::find(callers.begin(), callers.end(), it->first) == callers.end())
+        {
+          // Latched messages can have old timestamps so set the timestamp to the bag start time in this case
+          it->second.time = start;
+          bag.write(topic, it->second.time, it->second.msg, it->second.connection_header);
+        }
+      }
     }
   }
   catch (rosbag::BagException const& err)

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -113,7 +113,7 @@ std::string SnapshotMessage::getCallerId() const
   return callerid;
 }
 
-bool SnapshotMessage::is_latched() const
+bool SnapshotMessage::isLatched() const
 {
   return connection_header->find("latching") != connection_header->end();
 }
@@ -243,7 +243,7 @@ void MessageQueue::_push(SnapshotMessage const& _out)
 
   std::string callerId = _out.getCallerId();
   // Save the latest from each publisher on a latched topic
-  if (_out.is_latched())
+  if (_out.isLatched())
   {
     auto it = latest_latched.find(callerId);
 
@@ -287,7 +287,7 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const& start, Time const
 
   // Increment / Decrement iterators until time contraints are met
   // Don't increment the begin iterator for latched messages since their timestamps can be old
-  if (!start.isZero() && !is_latched())
+  if (!start.isZero() && !isLatched())
   {
     while (begin != end && (*begin).time < start)
       ++begin;
@@ -300,7 +300,7 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const& start, Time const
   return range_t(begin, end);
 }
 
-bool MessageQueue::is_latched()
+bool MessageQueue::isLatched()
 {
   return !latest_latched.empty();
 }
@@ -420,7 +420,7 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
   try
   {
     ros::Time start = req.start_time;
-    bool latched = message_queue.is_latched();
+    bool latched = message_queue.isLatched();
 
     if (start == ros::Time(0))
     {


### PR DESCRIPTION
@ayrton04 noticed there was only one message from each costmap topic in bump bags.

For some reason in my last PR, I added logic so that we end up with only one message from each unique publisher on any given latched topic. Not sure why I did that, but this undoes that change so the bump bags will have all of the messages from latched topics.