### PR TITLE
RST-7860 Update Old Timestamps

### DIFF
--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -421,11 +421,14 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
   {
     ros::Time start = req.start_time;
     bool latched = message_queue.isLatched();
+    // ROS_WARN_STREAM("Bagging messages for topic " << message_queue.)
 
     if (start == ros::Time(0))
     {
       start = now - message_queue.options_.duration_limit_;
     }
+
+    ROS_WARN_STREAM("Set start time to " << start);
 
     std::vector<std::string> callers;
     for (MessageQueue::range_t::first_type msg_it = range.first; msg_it != range.second; ++msg_it)
@@ -434,6 +437,7 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
       // Latched messages can have old timestamps so set the timestamp to the bag start time in this case
       if (msg.time < start)
       {
+        ROS_WARN_STREAM("Updating old timestamp " << msg.time);
         msg.time = start;
       }
       bag.write(topic, msg.time, msg.msg, msg.connection_header);

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -427,8 +427,6 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
       start = now - message_queue.options_.duration_limit_;
     }
 
-    bool logged_timestamp_update = false;
-
     std::vector<std::string> callers;
     for (MessageQueue::range_t::first_type msg_it = range.first; msg_it != range.second; ++msg_it)
     {
@@ -436,10 +434,6 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
       // Latched messages can have old timestamps so set the timestamp to the bag start time in this case
       if (msg.time < start)
       {
-        if (!logged_timestamp_update)
-        {
-          logged_timestamp_update = true;
-        }
         msg.time = start;
       }
       bag.write(topic, msg.time, msg.msg, msg.connection_header);

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -421,14 +421,15 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
   {
     ros::Time start = req.start_time;
     bool latched = message_queue.isLatched();
-    // ROS_WARN_STREAM("Bagging messages for topic " << message_queue.)
+    ROS_WARN_STREAM("Bagging messages for topic " << topic);
 
     if (start == ros::Time(0))
     {
       start = now - message_queue.options_.duration_limit_;
+      ROS_WARN_STREAM("\tSet start time to " << start);
     }
 
-    ROS_WARN_STREAM("Set start time to " << start);
+    bool logged_timestamp_update = false;
 
     std::vector<std::string> callers;
     for (MessageQueue::range_t::first_type msg_it = range.first; msg_it != range.second; ++msg_it)
@@ -437,7 +438,11 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
       // Latched messages can have old timestamps so set the timestamp to the bag start time in this case
       if (msg.time < start)
       {
-        ROS_WARN_STREAM("Updating old timestamp " << msg.time);
+        if (!logged_timestamp_update)
+        {
+          ROS_WARN_STREAM("\tUpdating old timestamp " << msg.time);
+          logged_timestamp_update = true;
+        }
         msg.time = start;
       }
       bag.write(topic, msg.time, msg.msg, msg.connection_header);

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -422,7 +422,7 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
     ros::Time start = req.start_time;
     bool latched = message_queue.isLatched();
 
-    if (start == ros::Time(0))
+    if (start.is_zero())
     {
       start = now - message_queue.options_.duration_limit_;
     }

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -421,12 +421,10 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
   {
     ros::Time start = req.start_time;
     bool latched = message_queue.isLatched();
-    ROS_WARN_STREAM("Bagging messages for topic " << topic);
 
     if (start == ros::Time(0))
     {
       start = now - message_queue.options_.duration_limit_;
-      ROS_WARN_STREAM("\tSet start time to " << start);
     }
 
     bool logged_timestamp_update = false;
@@ -440,7 +438,6 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
       {
         if (!logged_timestamp_update)
         {
-          ROS_WARN_STREAM("\tUpdating old timestamp " << msg.time);
           logged_timestamp_update = true;
         }
         msg.time = start;
@@ -466,6 +463,12 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
         // If any known latched publishers are not included in this bag, add the latest message from them
         if (std::find(callers.begin(), callers.end(), it->first) == callers.end())
         {
+          // Latched messages can have old timestamps so set the timestamp to the bag start time in this case
+          if (it->second.time < start)
+          {
+            it->second.time = start;
+          }
+
           bag.write(topic, it->second.time, it->second.msg, it->second.connection_header);
         }
       }
@@ -482,8 +485,6 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
 bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
                                    rosbag_snapshot_msgs::TriggerSnapshot::Response& res)
 {
-  ROS_WARN_STREAM("received trigger request with start_time " << req.start_time);
-
   if (!postfixFilename(req.filename))
   {
     res.success = false;

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -473,6 +473,8 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
 bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
                                    rosbag_snapshot_msgs::TriggerSnapshot::Response& res)
 {
+  ROS_WARN_STREAM("received trigger request with start_time " << req.start_time);
+
   if (!postfixFilename(req.filename))
   {
     res.success = false;

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -424,14 +424,7 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
 
     if (start == ros::Time(0))
     {
-      if (latched)
-      {
-        start = message_queue.queue_.front().time;
-      }
-      else
-      {
-        start = now - message_queue.options_.duration_limit_;
-      }
+      start = now - message_queue.options_.duration_limit_;
     }
 
     std::vector<std::string> callers;
@@ -464,8 +457,6 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
         // If any known latched publishers are not included in this bag, add the latest message from them
         if (std::find(callers.begin(), callers.end(), it->first) == callers.end())
         {
-          // Latched messages can have old timestamps so set the timestamp to the bag start time in this case
-          it->second.time = start;
           bag.write(topic, it->second.time, it->second.msg, it->second.connection_header);
         }
       }


### PR DESCRIPTION
Turns out I messed things up with my last PR by preserving old timestamps for latched messages instead of updating them to the start of the bag. Easy fix but I unfortunately chased my tail for a while by inadvertently breaking something else in a way that only presented itself when I was faking bumps on test floor robots.

I've tested this quite exhaustively in sim and with real bots, and by triggering bags in various ways, and everything seems to be working. Bag duration is never longer than the 11.5 second window set by the `LOCUS_BUMP_BAG_WINDOW` env var.