### PR TITLE
RST-9269 new bag naming options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,35 @@ It subscribes to topics and maintains a buffer of recent messages like a dash ca
 
 ```
 $ rosrun rosbag_snapshot snapshot -h
-Usage: snapshot [options] [topic1 topic2 ...]
+Usage: rosrun rosbag_snapshot snapshot [options] [topic1 topic2 ...]
 
 Buffer recent messages until triggered to write or trigger an already running instance.
 
 Options:
   -h [ --help ]                produce help message
   -t [ --trigger-write ]       Write buffer of selected topcis to a bag file
-  -p [ --pause ]               Stop buffering new messages until resumed or
+  -p [ --pause ]               Stop buffering new messages until resumed or 
                                write is triggered
-  -r [ --resume ]              Resume buffering new messages, writing over
+  -r [ --resume ]              Resume buffering new messages, writing over 
                                older messages as needed
-  -s [ --size ] arg (=-1)      Maximum memory per topic to use in buffering in
+  -a [ --all ]                 Record all topics
+  --use-start-time             Use the bag start time instead of the trigger 
+                               time for naming bag files. Default: false
+  --use-duration               Append the bag duration to the end of bag file 
+                               names. Default: false
+  --use-decimal-precision      Use decimal precision for seconds in the 
+                               timestamp portion of bag file names. Default: 
+                               false
+  -s [ --size ] arg (=-1)      Maximum memory per topic to use in buffering in 
                                MB. Default: no limit
-  -d [ --duration ] arg (=30)  Maximum difference between newest and oldest
-                               buffered message per topic in seconds. Default:
+  -c [ --count ] arg (=-1)     Maximum number of messages per topic to use when
+                               buffering. Default: no limit
+  -d [ --duration ] arg (=30)  Maximum difference between newest and oldest 
+                               buffered message per topic in seconds. Default: 
                                30
-  -o [ --output-prefix ] arg   When in trigger write mode, prepend PREFIX to
+  -o [ --output-prefix ] arg   When in trigger write mode, prepend PREFIX to 
                                name of writting bag file
-  -O [ --output-filename ] arg When in trigger write mode, exact name of
+  -O [ --output-filename ] arg When in trigger write mode, exact name of 
                                written bag file
   --topic arg                  Topic to buffer. If triggering write, write only
                                these topics instead of all buffered topics.

--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -184,10 +184,8 @@ public:
   int64_t getMessageSize(SnapshotMessage const& msg) const;
   // Latest messages from each publisher on a latched topic
   std::map<std::string, SnapshotMessage> latest_latched;
-  // Returns the time of the oldest message in the queue, or now if size < 1
-  ros::Time start() const;
-  // Returns the time of the newest message in the queue, or 0 if size < 1
-  ros::Time end() const;
+  // Returns the time of the oldest message in the queue, or trigger_time if size < 1
+  ros::Time start(ros::Time& trigger_time) const;
 
 private:
   // Internal push whitch does not obtain lock
@@ -243,9 +241,9 @@ private:
   // Replace individual topic limits with node defaults if they are flagged for it (see SnapshotterTopicOptions)
   void fixTopicOptions(SnapshotterTopicOptions& options);
   // If file is "prefix" mode (doesn't end in .bag), append current datetime and .bag to end
-  bool postfixFilename(std::string& file);
+  bool postfixFilename(std::string& file, ros::Time& trigger_time);
   /// Return current local datetime as a string such as 2018-05-22-14-28-51. Used to generate bag filenames
-  std::string timeAsStr();
+  std::string timeAsStr(ros::Time& trigger_time);
   // Clear the internal buffers of all topics. Used when resuming after a pause to avoid time gaps
   void clear();
   // Subscribe to one of the topics, setting up the callback to add to the respective queue
@@ -270,11 +268,10 @@ private:
   // If returns false, there was an error opening/writing the bag and an error message was written to res.message
   bool writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, std::string const& topic,
                   rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
-                  rosbag_snapshot_msgs::TriggerSnapshot::Response& res);
+                  rosbag_snapshot_msgs::TriggerSnapshot::Response& res,
+                  ros::Time& trigger_time);
   // Returns the time of the oldest message in the message buffers
-  ros::Time start() const;
-  // Returns the time of the newest message in the message buffers
-  ros::Time end() const;
+  ros::Time start(ros::Time& trigger_time) const;
 };
 
 // Configuration for SnapshotterClient

--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -101,9 +101,9 @@ struct ROSBAG_DECL SnapshotterOptions
   ros::Duration status_period_;
   // Flag if all topics should be recorded
   bool all_topics_;
-  // Flag to name snapshot bags with the bag start timestamp
+  // Flag to name bags with the bag start timestamp
   bool use_start_time_;
-  // Flag to append the bag duration to snapshot bag names
+  // Flag to append the bag duration to bag names
   bool use_duration_;
   // Use decimal precision for the seconds portion of bag name timestamps
   bool use_decimal_precision_;

--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -178,6 +178,10 @@ public:
   int64_t getMessageSize(SnapshotMessage const& msg) const;
   // Latest messages from each publisher on a latched topic
   std::map<std::string, SnapshotMessage> latest_latched;
+  // Returns the time of the oldest message in the queue, or now if size < 1
+  ros::Time start() const;
+  // Returns the time of the newest message in the queue, or 0 if size < 1
+  ros::Time end() const;
 
 private:
   // Internal push whitch does not obtain lock
@@ -192,7 +196,7 @@ private:
   // impossible.
   bool preparePush(int32_t size, ros::Time const& time, const std::string& callerid);
   // Returns true if queue contains latched messages, false if not or queue is empty. Does not obtain lock
-  bool isLatched();
+  bool isLatched() const;
   // Removes all messages from the specified callerid
   void removeCallerid(const std::string& callerid);
 };
@@ -261,6 +265,11 @@ private:
   bool writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, std::string const& topic,
                   rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
                   rosbag_snapshot_msgs::TriggerSnapshot::Response& res);
+  ros::Duration longestTopicDuration();
+  // Returns the time of the oldest message in the message buffers
+  ros::Time start() const;
+  // Returns the time of the newest message in the message buffers
+  ros::Time end() const;
 };
 
 // Configuration for SnapshotterClient

--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -101,6 +101,10 @@ struct ROSBAG_DECL SnapshotterOptions
   ros::Duration status_period_;
   // Flag if all topics should be recorded
   bool all_topics_;
+  // Flag to name snapshot bags with the bag start timestamp
+  bool use_start_time_;
+  // Flag to append the bag duration to snapshot bag names
+  bool use_duration_;
 
   typedef std::map<std::string, SnapshotterTopicOptions> topics_t;
   // Provides list of topics to snapshot and their limit configurations
@@ -265,7 +269,6 @@ private:
   bool writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, std::string const& topic,
                   rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
                   rosbag_snapshot_msgs::TriggerSnapshot::Response& res);
-  ros::Duration longestTopicDuration();
   // Returns the time of the oldest message in the message buffers
   ros::Time start() const;
   // Returns the time of the newest message in the message buffers

--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -105,13 +105,15 @@ struct ROSBAG_DECL SnapshotterOptions
   bool use_start_time_;
   // Flag to append the bag duration to snapshot bag names
   bool use_duration_;
+  // Use decimal precision for the seconds portion of bag name timestamps
+  bool use_decimal_precision_;
 
   typedef std::map<std::string, SnapshotterTopicOptions> topics_t;
   // Provides list of topics to snapshot and their limit configurations
   topics_t topics_;
 
   SnapshotterOptions(ros::Duration default_duration_limit = ros::Duration(30), int32_t default_memory_limit = -1,
-                     int32_t default_count_limit = -1, ros::Duration status_period = ros::Duration(1));
+                     int32_t default_count_limit = -1, ros::Duration status_period = ros::Duration(1), bool use_decimal_precicision = false);
 
   // Add a new topic to the configuration, returns false if the topic was already present
   bool addTopic(std::string const& topic,

--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -113,7 +113,7 @@ struct ROSBAG_DECL SnapshotterOptions
   topics_t topics_;
 
   SnapshotterOptions(ros::Duration default_duration_limit = ros::Duration(30), int32_t default_memory_limit = -1,
-                     int32_t default_count_limit = -1, ros::Duration status_period = ros::Duration(1), bool use_decimal_precicision = false);
+                     int32_t default_count_limit = -1, ros::Duration status_period = ros::Duration(1));
 
   // Add a new topic to the configuration, returns false if the topic was already present
   bool addTopic(std::string const& topic,

--- a/rosbag_snapshot/src/snapshot.cpp
+++ b/rosbag_snapshot/src/snapshot.cpp
@@ -161,6 +161,8 @@ void appendParamOptions(ros::NodeHandle& nh, SnapshotterOptions& opts)
   if (nh.getParam("default_count_limit", default_count))
     opts.default_count_limit_ = default_count;
   nh.param("record_all_topics", opts.all_topics_, opts.all_topics_);
+  nh.param("use_start_time", opts.use_start_time_, opts.use_start_time_);
+  nh.param("use_duration", opts.use_duration_, opts.use_duration_);
 
   if (!nh.getParam("topics", topics))
   {

--- a/rosbag_snapshot/src/snapshot.cpp
+++ b/rosbag_snapshot/src/snapshot.cpp
@@ -68,6 +68,9 @@ bool parseOptions(po::variables_map& vm, int argc, char** argv)
     ("pause,p", "Stop buffering new messages until resumed or write is triggered")
     ("resume,r", "Resume buffering new messages, writing over older messages as needed")
     ("all,a", "Record all topics")
+    ("use-start-time", "Use the bag start time instead of the trigger time for naming bag files. Default: false")
+    ("use-duration", "Append the bag duration to the end of bag file names. Default: false")
+    ("use-decimal-precision", "Use decimal precision for seconds in the timestamp portion of bag file names. Default: false")
     ("size,s", po::value<double>()->default_value(-1),
      "Maximum memory per topic to use in buffering in MB. Default: no limit")
     ("count,c", po::value<int32_t>()->default_value(-1),
@@ -120,6 +123,9 @@ bool parseVariablesMap(SnapshotterOptions& opts, po::variables_map const& vm)
   opts.default_duration_limit_ = ros::Duration(vm["duration"].as<double>());
   opts.default_count_limit_ =  vm["count"].as<int32_t>();
   opts.all_topics_ = vm.count("all");
+  opts.use_start_time_ = vm.count("use-start-time");
+  opts.use_duration_ = vm.count("use-duration");
+  opts.use_decimal_precision_ =  vm.count("use-decimal-precision");
   return true;
 }
 
@@ -163,6 +169,7 @@ void appendParamOptions(ros::NodeHandle& nh, SnapshotterOptions& opts)
   nh.param("record_all_topics", opts.all_topics_, opts.all_topics_);
   nh.param("use_start_time", opts.use_start_time_, opts.use_start_time_);
   nh.param("use_duration", opts.use_duration_, opts.use_duration_);
+  nh.param("use_decimal_precision", opts.use_decimal_precision_, opts.use_decimal_precision_);
 
   if (!nh.getParam("topics", topics))
   {

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -389,8 +389,19 @@ string Snapshotter::timeAsStr()
   boost::posix_time::time_duration duration = buffer_end - buffer_start;
   boost::posix_time::time_facet* const f = new boost::posix_time::time_facet("%Y-%m-%d-%H-%M-%S.%f");
   msg.imbue(std::locale(msg.getloc(), f));
-  msg << buffer_start;
-  msg << "_" << std::fixed << std::setprecision(3) << float(duration.total_milliseconds()) / 1000;
+
+  if (options_.use_start_time_)
+  {
+    msg << buffer_start;
+  }
+  else{
+    msg << buffer_end;
+  }
+
+  if (options_.use_start_time_) {
+    msg << "_" << std::fixed << std::setprecision(3) << float(duration.total_milliseconds()) / 1000;
+  }
+
   return msg.str();
 }
 
@@ -740,17 +751,6 @@ int Snapshotter::run()
   ros::MultiThreadedSpinner spinner(4);  // Use 4 threads
   spinner.spin();                        // spin() will not return until the node has been shutdown
   return 0;
-}
-
-ros::Duration Snapshotter::longestTopicDuration() {
-  ros::Duration longest = ros::Duration(0);
-
-  for (const auto& b : buffers_) {
-    ros::Duration duration = b.second.get()->duration();
-    if (duration > longest) longest = duration;
-  }
-
-  return longest;
 }
 
 ros::Time Snapshotter::start() const

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -69,11 +69,12 @@ SnapshotterTopicOptions::SnapshotterTopicOptions(ros::Duration duration_limit, i
 }
 
 SnapshotterOptions::SnapshotterOptions(ros::Duration default_duration_limit, int32_t default_memory_limit,
-                                     int32_t default_count_limit, ros::Duration status_period)
+                                     int32_t default_count_limit, ros::Duration status_period, bool use_decimal_precicision)
   : default_duration_limit_(default_duration_limit)
   , default_memory_limit_(default_memory_limit)
   , default_count_limit_(default_count_limit)
   , status_period_(status_period)
+  , use_decimal_precision_(use_decimal_precicision)
   , topics_()
 {
 }
@@ -386,9 +387,20 @@ string Snapshotter::timeAsStr()
   std::stringstream msg;
   const boost::posix_time::ptime buffer_start = start().toBoost();
   const boost::posix_time::ptime buffer_end = end().toBoost();
-  boost::posix_time::time_duration duration = buffer_end - buffer_start;
-  boost::posix_time::time_facet* const f = new boost::posix_time::time_facet("%Y-%m-%d-%H-%M-%S.%f");
-  msg.imbue(std::locale(msg.getloc(), f));
+
+  bool thing = true;
+  // boost::posix_time::time_facet* const f;
+
+  if (options_.use_decimal_precision_)
+  {
+    boost::posix_time::time_facet* const f = new boost::posix_time::time_facet("%Y-%m-%d-%H-%M-%S.%f");
+    msg.imbue(std::locale(msg.getloc(), f));
+  }
+  else
+  {
+    boost::posix_time::time_facet* const f = new boost::posix_time::time_facet("%Y-%m-%d-%H-%M-%S");
+    msg.imbue(std::locale(msg.getloc(), f));
+  }
 
   if (options_.use_start_time_)
   {
@@ -398,7 +410,8 @@ string Snapshotter::timeAsStr()
     msg << buffer_end;
   }
 
-  if (options_.use_start_time_) {
+  if (options_.use_duration_) {
+    boost::posix_time::time_duration duration = buffer_end - buffer_start;
     msg << "_" << std::fixed << std::setprecision(3) << float(duration.total_milliseconds()) / 1000;
   }
 
@@ -529,12 +542,6 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
 bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
                                    rosbag_snapshot_msgs::TriggerSnapshot::Response& res)
 {
-  if (!postfixFilename(req.filename))
-  {
-    res.success = false;
-    res.message = "invalid";
-    return true;
-  }
   bool recording_prior;  // Store if we were recording prior to write to restore this state after write
   {
     boost::upgrade_lock<boost::upgrade_mutex> read_lock(state_lock_);
@@ -549,6 +556,13 @@ bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Reque
     if (recording_prior)
       pause();
     writing_ = true;
+  }
+
+  if (!postfixFilename(req.filename))
+  {
+    res.success = false;
+    res.message = "invalid";
+    return true;
   }
 
   // Ensure that state is updated when function exits, regardlesss of branch path / exception events

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -300,9 +300,45 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const& start, Time const
   return range_t(begin, end);
 }
 
-bool MessageQueue::isLatched()
+bool MessageQueue::isLatched() const
 {
   return !latest_latched.empty();
+}
+
+ros::Time MessageQueue::start() const
+{
+  ros::Time now = ros::Time::now();
+  ros::Time start = queue_.front().time;
+
+  if (queue_.empty())
+  {
+    return now;
+  }
+  else if (isLatched()) {
+    // Latched topics can have timestamps before the duration limit that are modified to fall within the duration
+    // upon writing to a bag, so set the start to the beginning of the duration in these cases
+    if (now - start > options_.duration_limit_) {
+      return now - options_.duration_limit_;
+    } else {
+      return start;
+    }
+  }
+  else
+  {
+    return start;
+  }
+}
+
+ros::Time MessageQueue::end() const
+{
+  if (queue_.empty())
+  {
+    return ros::Time(0);
+  }
+  else
+  {
+    return queue_.back().time;
+  }
 }
 
 const int Snapshotter::QUEUE_SIZE = 10;
@@ -348,10 +384,13 @@ bool Snapshotter::postfixFilename(string& file)
 string Snapshotter::timeAsStr()
 {
   std::stringstream msg;
-  const boost::posix_time::ptime now = boost::posix_time::second_clock::local_time();
-  boost::posix_time::time_facet* const f = new boost::posix_time::time_facet("%Y-%m-%d-%H-%M-%S");
+  const boost::posix_time::ptime buffer_start = start().toBoost();
+  const boost::posix_time::ptime buffer_end = end().toBoost();
+  boost::posix_time::time_duration duration = buffer_end - buffer_start;
+  boost::posix_time::time_facet* const f = new boost::posix_time::time_facet("%Y-%m-%d-%H-%M-%S.%f");
   msg.imbue(std::locale(msg.getloc(), f));
-  msg << now;
+  msg << buffer_start;
+  msg << "_" << std::fixed << std::setprecision(3) << float(duration.total_milliseconds() / 1000);
   return msg.str();
 }
 
@@ -701,6 +740,48 @@ int Snapshotter::run()
   ros::MultiThreadedSpinner spinner(4);  // Use 4 threads
   spinner.spin();                        // spin() will not return until the node has been shutdown
   return 0;
+}
+
+ros::Duration Snapshotter::longestTopicDuration() {
+  ros::Duration longest = ros::Duration(0);
+
+  for (const auto& b : buffers_) {
+    ros::Duration duration = b.second.get()->duration();
+    if (duration > longest) longest = duration;
+  }
+
+  return longest;
+}
+
+ros::Time Snapshotter::start() const
+{
+  ros::Time oldest = ros::Time::now();
+
+  for (const auto& b : buffers_) {
+    ros::Time start = b.second.get()->start();
+    if (start < oldest)
+    {
+      oldest = start;
+    }
+  }
+
+  return oldest;
+}
+
+ros::Time Snapshotter::end() const
+{
+  ros::Time newest = ros::Time(0);
+
+  for (const auto& b : buffers_) {
+    ros::Time end = b.second.get()->end();
+
+    if (end > newest)
+    {
+      newest = end;
+    }
+  }
+
+  return newest;
 }
 
 SnapshotterClient::SnapshotterClient()

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -69,12 +69,11 @@ SnapshotterTopicOptions::SnapshotterTopicOptions(ros::Duration duration_limit, i
 }
 
 SnapshotterOptions::SnapshotterOptions(ros::Duration default_duration_limit, int32_t default_memory_limit,
-                                     int32_t default_count_limit, ros::Duration status_period, bool use_decimal_precicision)
+                                     int32_t default_count_limit, ros::Duration status_period)
   : default_duration_limit_(default_duration_limit)
   , default_memory_limit_(default_memory_limit)
   , default_count_limit_(default_count_limit)
   , status_period_(status_period)
-  , use_decimal_precision_(use_decimal_precicision)
   , topics_()
 {
 }

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -306,20 +306,19 @@ bool MessageQueue::isLatched() const
   return !latest_latched.empty();
 }
 
-ros::Time MessageQueue::start() const
+ros::Time MessageQueue::start(ros::Time& trigger_time) const
 {
-  ros::Time now = ros::Time::now();
   ros::Time start = queue_.front().time;
 
   if (queue_.empty())
   {
-    return now;
+    return trigger_time;
   }
   else if (isLatched()) {
-    // Latched topics can have timestamps before the duration limit that are modified to fall within the duration
+    // Latched topics can have timestamps before the duration limit that are modified to the start of the duration
     // upon writing to a bag, so set the start to the beginning of the duration in these cases
-    if (now - start > options_.duration_limit_) {
-      return now - options_.duration_limit_;
+    if (trigger_time - start > options_.duration_limit_) {
+      return trigger_time - options_.duration_limit_;
     } else {
       return start;
     }
@@ -327,18 +326,6 @@ ros::Time MessageQueue::start() const
   else
   {
     return start;
-  }
-}
-
-ros::Time MessageQueue::end() const
-{
-  if (queue_.empty())
-  {
-    return ros::Time(0);
-  }
-  else
-  {
-    return queue_.back().time;
   }
 }
 
@@ -369,27 +356,26 @@ void Snapshotter::fixTopicOptions(SnapshotterTopicOptions& options)
     options.count_limit_ = options_.default_memory_limit_;
 }
 
-bool Snapshotter::postfixFilename(string& file)
+bool Snapshotter::postfixFilename(string& file, ros::Time& trigger_time)
 {
   size_t ind = file.rfind(".bag");
-  // If requested ends in .bag, this is literal name do not append date
+
+  // If requested ends in .bag, this is literal name do not append date 
   if (ind != string::npos && ind == file.size() - 4)
   {
     return true;
   }
+
   // Otherwise treat as prefix and append datetime and extension
-  file += timeAsStr() + ".bag";
+  file += timeAsStr(trigger_time) + ".bag";
   return true;
 }
 
-string Snapshotter::timeAsStr()
+string Snapshotter::timeAsStr(ros::Time& trigger_time)
 {
   std::stringstream msg;
-  const boost::posix_time::ptime buffer_start = start().toBoost();
-  const boost::posix_time::ptime buffer_end = end().toBoost();
-
-  bool thing = true;
-  // boost::posix_time::time_facet* const f;
+  const boost::posix_time::ptime buffer_start = start(trigger_time).toBoost();
+  const boost::posix_time::ptime buffer_end = trigger_time.toBoost();
 
   if (options_.use_decimal_precision_)
   {
@@ -454,10 +440,9 @@ void Snapshotter::subscribe(string const& topic, boost::shared_ptr<MessageQueue>
 
 bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, string const& topic,
                              rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
-                             rosbag_snapshot_msgs::TriggerSnapshot::Response& res)
+                             rosbag_snapshot_msgs::TriggerSnapshot::Response& res,
+                             ros::Time& trigger_time)
 {
-  ros::Time now = ros::Time::now();
-
   // acquire lock for this queue
   boost::mutex::scoped_lock l(message_queue.lock);
 
@@ -487,7 +472,7 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
 
     if (start.is_zero())
     {
-      start = now - message_queue.options_.duration_limit_;
+      start = trigger_time - message_queue.options_.duration_limit_;
     }
 
     std::vector<std::string> callers;
@@ -542,6 +527,8 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
 bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
                                    rosbag_snapshot_msgs::TriggerSnapshot::Response& res)
 {
+  ros::Time trigger_time = ros::Time::now();
+  
   bool recording_prior;  // Store if we were recording prior to write to restore this state after write
   {
     boost::upgrade_lock<boost::upgrade_mutex> read_lock(state_lock_);
@@ -558,7 +545,7 @@ bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Reque
     writing_ = true;
   }
 
-  if (!postfixFilename(req.filename))
+  if (!postfixFilename(req.filename, trigger_time))
   {
     res.success = false;
     res.message = "invalid";
@@ -605,7 +592,7 @@ bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Reque
         continue;
       }
       MessageQueue& message_queue = *(*found).second;
-      if (!writeTopic(bag, message_queue, topic, req, res))
+      if (!writeTopic(bag, message_queue, topic, req, res, trigger_time))
         return true;
     }
   }
@@ -616,7 +603,7 @@ bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Reque
     {
       MessageQueue& message_queue = *(pair.second);
       std::string const& topic = pair.first;
-      if (!writeTopic(bag, message_queue, topic, req, res))
+      if (!writeTopic(bag, message_queue, topic, req, res, trigger_time))
         return true;
     }
   }
@@ -767,12 +754,12 @@ int Snapshotter::run()
   return 0;
 }
 
-ros::Time Snapshotter::start() const
+ros::Time Snapshotter::start(ros::Time& trigger_time) const
 {
-  ros::Time oldest = ros::Time::now();
+  ros::Time oldest = trigger_time;
 
   for (const auto& b : buffers_) {
-    ros::Time start = b.second.get()->start();
+    ros::Time start = b.second.get()->start(trigger_time);
     if (start < oldest)
     {
       oldest = start;
@@ -780,22 +767,6 @@ ros::Time Snapshotter::start() const
   }
 
   return oldest;
-}
-
-ros::Time Snapshotter::end() const
-{
-  ros::Time newest = ros::Time(0);
-
-  for (const auto& b : buffers_) {
-    ros::Time end = b.second.get()->end();
-
-    if (end > newest)
-    {
-      newest = end;
-    }
-  }
-
-  return newest;
 }
 
 SnapshotterClient::SnapshotterClient()

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -390,7 +390,7 @@ string Snapshotter::timeAsStr()
   boost::posix_time::time_facet* const f = new boost::posix_time::time_facet("%Y-%m-%d-%H-%M-%S.%f");
   msg.imbue(std::locale(msg.getloc(), f));
   msg << buffer_start;
-  msg << "_" << std::fixed << std::setprecision(3) << float(duration.total_milliseconds() / 1000);
+  msg << "_" << std::fixed << std::setprecision(3) << float(duration.total_milliseconds()) / 1000;
   return msg.str();
 }
 

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -308,18 +308,22 @@ bool MessageQueue::isLatched() const
 
 ros::Time MessageQueue::start(ros::Time& trigger_time) const
 {
-  ros::Time start = queue_.front().time;
-
   if (queue_.empty())
   {
     return trigger_time;
   }
-  else if (isLatched()) {
+
+  ros::Time start = queue_.front().time;
+
+  if (isLatched()) {
     // Latched topics can have timestamps before the duration limit that are modified to the start of the duration
     // upon writing to a bag, so set the start to the beginning of the duration in these cases
-    if (trigger_time - start > options_.duration_limit_) {
+    if (trigger_time - start > options_.duration_limit_)
+    {
       return trigger_time - options_.duration_limit_;
-    } else {
+    }
+    else
+    {
       return start;
     }
   }
@@ -396,7 +400,8 @@ string Snapshotter::timeAsStr(ros::Time& trigger_time)
     msg << buffer_end;
   }
 
-  if (options_.use_duration_) {
+  if (options_.use_duration_)
+  {
     boost::posix_time::time_duration duration = buffer_end - buffer_start;
     msg << "_" << std::fixed << std::setprecision(3) << float(duration.total_milliseconds()) / 1000;
   }
@@ -758,8 +763,10 @@ ros::Time Snapshotter::start(ros::Time& trigger_time) const
 {
   ros::Time oldest = trigger_time;
 
-  for (const auto& b : buffers_) {
+  for (const auto& b : buffers_)
+  {
     ros::Time start = b.second.get()->start(trigger_time);
+
     if (start < oldest)
     {
       oldest = start;


### PR DESCRIPTION
There's new services that search for and upload bags to S3 for later analysis. These services use a combination of the bag name (which includes a timestamp) and some env vars to determine when each bag starts and ends and if it falls within the search window.

This is a little tricky with "snapshot" bags (bags created by the snapshot node), since these are named with the timestamp of when the bag was triggered, i.e. the end time of the bag, while our "normal" bags are named with the timestamp of when the bag starts, so we need [special logic](https://github.com/locusrobotics/locus_triage/blob/671344c2c7378bc4ccb25861300fdd3e962de655/src/locus_triage/bag_search.py#L44) to handle that.

The bag search also uses the `LOCUS_BUMP_BAG_WINDOW` var to determine the duration of snapshot bags (defaults to 11.5 seconds), but rosbag_snapshot is capable of setting different duration limits for each topic so this is not always a safe assumption.

To help future proof things, this adds options to name snapshot bags with the start timestamp like our other bags, and also adds options to use decimal precision for the seconds portion of the timestamp and append the bag duration to the end. This means the bag name itself has all the information we need to determine if it falls within a search window without making any assumptions.

In a related [locus_baggging PR](https://github.com/locusrobotics/locus_bagging/pull/100/files), I changed the launch to use these new options by default. This results in snapshot bags such as the following, where the timestamp matches the start time of the bag (with decimal precision) and the bag duration is appended to the end:
```
$ rosbag info bump_sim_001_2024-02-28-13-28-59.262269_11.500.bag 
path:        bump_sim_001_2024-02-28-13-28-59.262269_11.500.bag
version:     2.0
duration:    11.5s
start:       Feb 28 2024 13:28:59.26 (1709144939.26)
end:         Feb 28 2024 13:29:10.76 (1709144950.76)
```